### PR TITLE
Enable deault values to fill the field value

### DIFF
--- a/classes/PodsForm.php
+++ b/classes/PodsForm.php
@@ -215,6 +215,11 @@ class PodsForm {
 			$value = self::default_value( $value, $type, $name, $options, $pod, $id );
 		}
 
+
+		if ( empty( $value ) ) {
+			$value = self::default_value( $value, $type, $name, $options, $pod, $id );
+		}
+		
 		// Fix double help qtip when using single checkboxes (boolean type)
 		if ( 'boolean' === $type ) {
 			$options['help'] = '';


### PR DESCRIPTION
instead of staying in just the placeholder, this checks if the value is empty, and if so, set the default value to it.

## Description

When using a Plain Number field in user meta, in a group, the default values aren't saved when saving the profile.

## Related GitHub issue(s)

See #7222

## Testing instructions

See #7222


## Screenshots / screencast
none

## Changelog text for these changes
 - [x] Empty values for Input Number field in User meta don't get default values. closes #7222

## PR checklist

- [x] I have tested my own code to confirm it works as I intended.
- [x] My code follows the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] My code follows the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
- [ ] My code includes automated tests for PHP and/or JS (if applicable).
